### PR TITLE
emoji in materials, collapsable table of content, mode switcher

### DIFF
--- a/site/assets/css/main.css
+++ b/site/assets/css/main.css
@@ -10,3 +10,8 @@ color: #2563eb; /* Tailwind blue-600 */
 border-left: 2px solid #2563eb;
 padding-left: 0.5rem;
 }
+
+li ul {
+padding-left: 0.5rem;
+font-size: 80%;
+}

--- a/site/assets/css/output.css
+++ b/site/assets/css/output.css
@@ -272,6 +272,9 @@
       max-width: 96rem;
     }
   }
+  .m-1 {
+    margin: calc(var(--spacing) * 1);
+  }
   .m-2 {
     margin: calc(var(--spacing) * 2);
   }
@@ -805,6 +808,9 @@
   .transform {
     transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
   }
+  .cursor-pointer {
+    cursor: pointer;
+  }
   .resize {
     resize: both;
   }
@@ -849,6 +855,9 @@
   }
   .gap-4 {
     gap: calc(var(--spacing) * 4);
+  }
+  .gap-5 {
+    gap: calc(var(--spacing) * 5);
   }
   .gap-10 {
     gap: calc(var(--spacing) * 10);
@@ -964,6 +973,9 @@
   }
   .pr-2 {
     padding-right: calc(var(--spacing) * 2);
+  }
+  .pl-2 {
+    padding-left: calc(var(--spacing) * 2);
   }
   .text-center {
     text-align: center;

--- a/site/assets/css/output.css
+++ b/site/assets/css/output.css
@@ -766,10 +766,6 @@
     width: calc(var(--spacing) * 5);
     height: calc(var(--spacing) * 5);
   }
-  .size-8 {
-    width: calc(var(--spacing) * 8);
-    height: calc(var(--spacing) * 8);
-  }
   .size-10 {
     width: calc(var(--spacing) * 10);
     height: calc(var(--spacing) * 10);
@@ -844,9 +840,6 @@
   .justify-items-center {
     justify-items: center;
   }
-  .gap-1 {
-    gap: calc(var(--spacing) * 1);
-  }
   .gap-2 {
     gap: calc(var(--spacing) * 2);
   }
@@ -855,12 +848,6 @@
   }
   .gap-4 {
     gap: calc(var(--spacing) * 4);
-  }
-  .gap-5 {
-    gap: calc(var(--spacing) * 5);
-  }
-  .gap-10 {
-    gap: calc(var(--spacing) * 10);
   }
   .gap-y-3 {
     row-gap: calc(var(--spacing) * 3);
@@ -905,14 +892,8 @@
   .border-blue-200 {
     border-color: var(--color-blue-200);
   }
-  .border-gray-200 {
-    border-color: var(--color-gray-200);
-  }
   .border-gray-500 {
     border-color: var(--color-gray-500);
-  }
-  .border-gray-800 {
-    border-color: var(--color-gray-800);
   }
   .border-gray-950\/5 {
     border-color: color-mix(in srgb, oklch(13% 0.028 261.692) 5%, transparent);
@@ -970,12 +951,6 @@
   }
   .pt-20 {
     padding-top: calc(var(--spacing) * 20);
-  }
-  .pr-2 {
-    padding-right: calc(var(--spacing) * 2);
-  }
-  .pl-2 {
-    padding-left: calc(var(--spacing) * 2);
   }
   .text-center {
     text-align: center;
@@ -1348,11 +1323,6 @@
       border-color: var(--color-blue-950);
     }
   }
-  .dark\:border-gray-800 {
-    &:where(.dark, .dark *) {
-      border-color: var(--color-gray-800);
-    }
-  }
   .dark\:border-white\/10 {
     &:where(.dark, .dark *) {
       border-color: color-mix(in srgb, #fff 10%, transparent);
@@ -1516,6 +1486,10 @@
   color: #2563eb;
   border-left: 2px solid #2563eb;
   padding-left: 0.5rem;
+}
+li ul {
+  padding-left: 0.5rem;
+  font-size: 80%;
 }
 @property --tw-rotate-x {
   syntax: "*";

--- a/site/assets/css/output.css
+++ b/site/assets/css/output.css
@@ -838,6 +838,9 @@
   .justify-items-center {
     justify-items: center;
   }
+  .gap-1 {
+    gap: calc(var(--spacing) * 1);
+  }
   .gap-2 {
     gap: calc(var(--spacing) * 2);
   }
@@ -846,6 +849,9 @@
   }
   .gap-4 {
     gap: calc(var(--spacing) * 4);
+  }
+  .gap-10 {
+    gap: calc(var(--spacing) * 10);
   }
   .gap-y-3 {
     row-gap: calc(var(--spacing) * 3);
@@ -871,6 +877,10 @@
     border-style: var(--tw-border-style);
     border-width: 1px;
   }
+  .border-1 {
+    border-style: var(--tw-border-style);
+    border-width: 1px;
+  }
   .border-2 {
     border-style: var(--tw-border-style);
     border-width: 2px;
@@ -886,8 +896,14 @@
   .border-blue-200 {
     border-color: var(--color-blue-200);
   }
+  .border-gray-200 {
+    border-color: var(--color-gray-200);
+  }
   .border-gray-500 {
     border-color: var(--color-gray-500);
+  }
+  .border-gray-800 {
+    border-color: var(--color-gray-800);
   }
   .border-gray-950\/5 {
     border-color: color-mix(in srgb, oklch(13% 0.028 261.692) 5%, transparent);
@@ -945,6 +961,9 @@
   }
   .pt-20 {
     padding-top: calc(var(--spacing) * 20);
+  }
+  .pr-2 {
+    padding-right: calc(var(--spacing) * 2);
   }
   .text-center {
     text-align: center;
@@ -1315,6 +1334,11 @@
   .dark\:border-blue-950 {
     &:where(.dark, .dark *) {
       border-color: var(--color-blue-950);
+    }
+  }
+  .dark\:border-gray-800 {
+    &:where(.dark, .dark *) {
+      border-color: var(--color-gray-800);
     }
   }
   .dark\:border-white\/10 {

--- a/site/assets/css/output.css
+++ b/site/assets/css/output.css
@@ -41,6 +41,8 @@
     --text-xl--line-height: calc(1.75 / 1.25);
     --text-2xl: 1.5rem;
     --text-2xl--line-height: calc(2 / 1.5);
+    --text-3xl: 1.875rem;
+    --text-3xl--line-height: calc(2.25 / 1.875);
     --font-weight-medium: 500;
     --font-weight-semibold: 600;
     --font-weight-bold: 700;
@@ -278,9 +280,6 @@
   }
   .m-4 {
     margin: calc(var(--spacing) * 4);
-  }
-  .m-5 {
-    margin: calc(var(--spacing) * 5);
   }
   .prose {
     color: var(--tw-prose-body);
@@ -954,6 +953,10 @@
     font-size: var(--text-2xl);
     line-height: var(--tw-leading, var(--text-2xl--line-height));
   }
+  .text-3xl {
+    font-size: var(--text-3xl);
+    line-height: var(--tw-leading, var(--text-3xl--line-height));
+  }
   .text-lg {
     font-size: var(--text-lg);
     line-height: var(--tw-leading, var(--text-lg--line-height));
@@ -1302,11 +1305,6 @@
       :where(.lg\:prose-xl > :last-child):not(:where([class~="not-prose"],[class~="not-prose"] *)) {
         margin-bottom: 0;
       }
-    }
-  }
-  .dark\:border-blue-200 {
-    &:where(.dark, .dark *) {
-      border-color: var(--color-blue-200);
     }
   }
   .dark\:border-blue-800 {

--- a/site/assets/js/main.js
+++ b/site/assets/js/main.js
@@ -63,6 +63,12 @@ document.addEventListener("DOMContentLoaded", () => {
               if (childListParent) {
                 childListParent.classList.remove("hidden");
               }
+
+              a2 = parentH3.querySelector("a");
+              a2.classList.add("toc-active");
+
+
+
             }
 
           }

--- a/site/assets/js/main.js
+++ b/site/assets/js/main.js
@@ -2,60 +2,83 @@
 document.documentElement.classList.toggle(
   "dark",
   localStorage.theme === "dark" ||
-    (!("theme" in localStorage) && window.matchMedia("(prefers-color-scheme: dark)").matches),
+  (!("theme" in localStorage) && window.matchMedia("(prefers-color-scheme: dark)").matches),
 );
 
 //console.log("hooray")
 
 document.addEventListener('DOMContentLoaded', () => {
 
-    light_mode = document.getElementById("light-mode");
-    dark_mode = document.getElementById("dark-mode");
-    system_mode = document.getElementById("system-mode");
+  light_mode = document.getElementById("light-mode");
+  dark_mode = document.getElementById("dark-mode");
+  system_mode = document.getElementById("system-mode");
 
-    light_mode.addEventListener('click', function() {
-        localStorage.theme = "light";
-        location.reload();
-    });
+  light_mode.addEventListener('click', function () {
+    localStorage.theme = "light";
+    location.reload();
+  });
 
-    dark_mode.addEventListener('click', function() {
-        localStorage.theme = "dark";
-        location.reload();
-    });
+  dark_mode.addEventListener('click', function () {
+    localStorage.theme = "dark";
+    location.reload();
+  });
 
 
-    system_mode.addEventListener('click', function() {
-        localStorage.removeItem("theme");
-        location.reload();
-    });
+  system_mode.addEventListener('click', function () {
+    localStorage.removeItem("theme");
+    location.reload();
+  });
 });
 
 document.addEventListener("DOMContentLoaded", () => {
-    const headings = document.querySelectorAll("article h2, article h3");
-    const tocLinks = document.querySelectorAll("#toc a");
+  const headings = document.querySelectorAll("article h2, article h3");
+  const tocLinks = document.querySelectorAll("#toc li");
 
-    const observer = new IntersectionObserver(entries => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          const id = entry.target.id;
-          tocLinks.forEach(link => {
-            link.classList.remove("toc-active");
-            if (link.getAttribute("href") === `#${id}`) {
-              link.classList.add("toc-active");
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        const id = entry.target.id;
+
+        tocLinks.forEach(l1 => {
+          // l1.classList.remove("toc-active");
+          let childList = l1.querySelector("ul");
+          if (childList) {
+            childList.classList.add("hidden");
+          }
+
+          a1 = l1.querySelector("a");
+          a1.classList.remove("toc-active");
+
+          if (a1.getAttribute("href") === `#${id}`) {
+            a1.classList.add("toc-active");
+
+            let childList = l1.querySelector("ul");
+            if (childList) {
+              childList.classList.remove("hidden");
             }
-//            console.log(`#${id}`)
-          });
-        }
-      });
-    }, {
-      rootMargin: "0px 0px -70% 0px", // triggers when heading is near top
-      threshold: 0
-    });
 
-    headings.forEach(heading => {
-      if (heading.id) observer.observe(heading);
+            parentH3 = l1.parentElement.parentElement;
+            if (parentH3.tagName === "LI") {
+              let childListParent = parentH3.querySelector("ul");
+              if (childListParent) {
+                childListParent.classList.remove("hidden");
+              }
+            }
+
+          }
+        });
+
+      }
     });
+  }, {
+    rootMargin: "0px 0px -70% 0px", // triggers when heading is near top
+    threshold: 0
   });
+
+  headings.forEach(heading => {
+    if (heading.id) observer.observe(heading);
+  });
+});
 
 document.addEventListener("DOMContentLoaded", () => {
   const menuButton = document.getElementById('menuButton');

--- a/site/assets/js/main.js
+++ b/site/assets/js/main.js
@@ -9,17 +9,25 @@ document.documentElement.classList.toggle(
 
 document.addEventListener('DOMContentLoaded', () => {
 
-    theme_switcher = document.getElementById("theme-switcher")
+    light_mode = document.getElementById("light-mode");
+    dark_mode = document.getElementById("dark-mode");
+    system_mode = document.getElementById("system-mode");
 
-    theme_switcher.addEventListener('click', function() {
-        if(localStorage.theme == "dark"){
-            localStorage.theme = "light";
-        }else{
-            localStorage.theme = "dark";
-        }
+    light_mode.addEventListener('click', function() {
+        localStorage.theme = "light";
         location.reload();
     });
 
+    dark_mode.addEventListener('click', function() {
+        localStorage.theme = "dark";
+        location.reload();
+    });
+
+
+    system_mode.addEventListener('click', function() {
+        localStorage.removeItem("theme");
+        location.reload();
+    });
 });
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/site/layouts/_partials/download-pdf-book.html
+++ b/site/layouts/_partials/download-pdf-book.html
@@ -1,7 +1,7 @@
 <div class="flex flex-col rounded items-center justify-center">
     {{ with .Parent }}
     <a href="/pdf{{ .RelPermalink }}output.pdf" target="_blank"
-       class="btn btn-primary border-2 border-blue-200 dark:border-blue-950 p-2" title="Download Book">
+       class="btn btn-primary p-2" title="Download Book">
         📘
     </a>
     {{ end }}

--- a/site/layouts/_partials/download-pdf-book.html
+++ b/site/layouts/_partials/download-pdf-book.html
@@ -1,8 +1,8 @@
 <div class="flex flex-col rounded items-center justify-center">
     {{ with .Parent }}
     <a href="/pdf{{ .RelPermalink }}output.pdf" target="_blank"
-       class="btn btn-primary border-2 border-blue-200 dark:border-blue-950 p-2">
-        Download Book
+       class="btn btn-primary border-2 border-blue-200 dark:border-blue-950 p-2" title="Download Book">
+        📘
     </a>
     {{ end }}
 </div>

--- a/site/layouts/_partials/download-pdf.html
+++ b/site/layouts/_partials/download-pdf.html
@@ -1,6 +1,6 @@
 <div class="flex flex-col rounded items-center justify-center">
     <a href="/pdf{{ .RelPermalink }}output.pdf" target="_blank"
-       class="btn btn-primary border-2 border-blue-200 dark:border-blue-950 p-2">
-        Download PDF
+       class="btn btn-primary border-2 border-blue-200 dark:border-blue-950 p-2" title="Download PDF">
+        📄
     </a>
 </div>

--- a/site/layouts/_partials/download-pdf.html
+++ b/site/layouts/_partials/download-pdf.html
@@ -1,6 +1,6 @@
 <div class="flex flex-col rounded items-center justify-center">
     <a href="/pdf{{ .RelPermalink }}output.pdf" target="_blank"
-       class="btn btn-primary border-2 border-blue-200 dark:border-blue-950 p-2" title="Download PDF">
+       class="btn btn-primary p-2" title="Download PDF">
         📄
     </a>
 </div>

--- a/site/layouts/_partials/footer.html
+++ b/site/layouts/_partials/footer.html
@@ -10,13 +10,12 @@
 
     <div class="flex items-center gap-4 mr-2">
 
-        <div class="rounded shadow p-1" id="theme-switcher">
+        <div class="flex flex-row rounded shadow p-1 gap-2" id="theme-switcher">
 
-            <svg width="800px" height="800px" viewBox="0 0 24 24" class="size-8 fill-black dark:fill-gray-400">
-                <path d="M12,22 C17.5228475,22 22,17.5228475 22,12 C22,6.4771525 17.5228475,2 12,2 C6.4771525,2 2,6.4771525 2,12 C2,17.5228475 6.4771525,22 12,22 Z M12,20 L12,4 C16.418278,4 20,7.581722 20,12 C20,16.418278 16.418278,20 12,20 Z"
-                      id="🎨-Color">
-                </path>
-            </svg>
+            <button id="light-mode" class="text-3xl" title="Light mode">☀️</button>
+            <button id="dark-mode" class="text-3xl" title="Dark mode">🌑</button>
+            <button id="system-mode" class="text-3xl" title="System mode">💻</button>
+
         </div>
 
     </div>

--- a/site/layouts/_partials/link-code.html
+++ b/site/layouts/_partials/link-code.html
@@ -1,7 +1,7 @@
 {{ if .Params.code }}
 <div class="flex flex-col rounded items-center justify-center">
     <a href="{{ .Params.Code }}" target="_blank"
-       class="btn btn-primary border-2 border-blue-200 dark:border-blue-950 p-2" title="Link to the code">
+       class="btn btn-primary p-2" title="Link to the code">
         🧑‍💻
     </a>
 </div>

--- a/site/layouts/_partials/link-code.html
+++ b/site/layouts/_partials/link-code.html
@@ -1,8 +1,8 @@
 {{ if .Params.code }}
 <div class="flex flex-col rounded items-center justify-center">
     <a href="{{ .Params.Code }}" target="_blank"
-       class="btn btn-primary border-2 border-blue-200 dark:border-blue-950 p-2">
-        🧑‍💻Link to the code
+       class="btn btn-primary border-2 border-blue-200 dark:border-blue-950 p-2" title="Link to the code">
+        🧑‍💻
     </a>
 </div>
 

--- a/site/layouts/_partials/sidebar-tutorial.html
+++ b/site/layouts/_partials/sidebar-tutorial.html
@@ -2,7 +2,7 @@
 
 {{ range where site.Sections "Section" "tutorials" }}
 
-<div class="flex flex-col dark:text-white rounded border-4 border-blue-200 dark:border-blue-800">
+<div class="flex flex-col gap-1 pr-2 dark:text-white rounded border-4 border-blue-200 dark:border-blue-800">
 
     <!--@formatter:off-->
     {{ range .Sections }}
@@ -12,14 +12,14 @@
             {{ .Title }}
         </a>
     </div>
-    {{ range .Pages }}
-    <div class="ml-4">
-        <a href="{{ .RelPermalink }}" class="hover:underline
-        {{ if eq .RelPermalink $current }}text-blue-500 dark:text-blue-300 underline font-semibold{{ end }}">
-            {{ .Title }}
-        </a>
-    </div>
-    {{ end }}
+        {{ range .Pages }}
+        <div class="ml-4 border-1 border-blue-200 dark:border-blue-800">
+            <a href="{{ .RelPermalink }}" class="hover:underline
+            {{ if eq .RelPermalink $current }}text-blue-500 dark:text-blue-300 underline font-semibold{{ end }}">
+                {{ .Title }}
+            </a>
+        </div>
+        {{ end }}
     {{ end }}
     <!--@formatter:on-->
 

--- a/site/layouts/_partials/sidebar-tutorial.html
+++ b/site/layouts/_partials/sidebar-tutorial.html
@@ -2,28 +2,26 @@
 
 {{ range where site.Sections "Section" "tutorials" }}
 
-<div class="flex flex-col gap-1 pr-2 dark:text-white rounded border-4 border-blue-200 dark:border-blue-800">
-
+<div class="flex flex-col gap-2 p-2 dark:text-white rounded border-4 border-blue-200 dark:border-blue-800">
     <!--@formatter:off-->
     {{ range .Sections }}
-    <div class="flex">
-        <a href="{{ .RelPermalink }}" class="hover:underline font-bold
-        {{ if eq .RelPermalink $current }}text-blue-500 dark:text-blue-300 underline{{ else }}text-gray-800 dark:text-gray-500{{ end }}">
+
+    <details class="flex flex-col gap-2" {{ if hasPrefix $current .RelPermalink }}open{{ end }}>
+        <summary class="cursor-pointer font-bold
+            {{ if eq .RelPermalink $current }}text-blue-500 dark:text-blue-300 underline{{ else }}text-gray-800 dark:text-gray-500{{ end }}">
             {{ .Title }}
-        </a>
-    </div>
+        </summary>
+
         {{ range .Pages }}
-        <div class="ml-4 border-1 border-blue-200 dark:border-blue-800">
+        <div class="m-1 border-1 border-blue-200 dark:border-blue-800">
             <a href="{{ .RelPermalink }}" class="hover:underline
             {{ if eq .RelPermalink $current }}text-blue-500 dark:text-blue-300 underline font-semibold{{ end }}">
                 {{ .Title }}
             </a>
         </div>
         {{ end }}
+    </details>
     {{ end }}
     <!--@formatter:on-->
-
-
 </div>
-
 {{ end }}


### PR DESCRIPTION
Add emojis instead of a full text on materials and add a title to them, so if anyone hovers on it, it would show more details.
Make sidebar table-of-content collapsable for each tutorial.
Make the table-of-content for each post collapsable if the h2 have multiple h3 on it.
Add system-mode alongside dark-mode and light-mode